### PR TITLE
change DSK format for use with PC Controller

### DIFF
--- a/flash_a_binary.py
+++ b/flash_a_binary.py
@@ -166,8 +166,8 @@ def print_out_dsk(serialno, board):
         print("DSK value: ", end = "")
         for x in range(40):
             print(sdk[x], end = "")
-            if (x + 1) % 5 == 0 and x > 0:
-                print(" - ", end = "")
+            if (x + 1) % 5 == 0 and x > 0 and (x + 1) < 40:
+                print("-", end = "")
 
 def parse_config_values() -> None:
     global commander

--- a/flash_a_workspace.py
+++ b/flash_a_workspace.py
@@ -168,8 +168,8 @@ def print_out_dsk(serialno, board):
         print("DSK value: ", end = "")
         for x in range(40):
             print(sdk[x], end = "")
-            if (x + 1) % 5 == 0 and x > 0:
-                print(" - ", end = "")
+            if (x + 1) % 5 == 0 and x > 0 and (x + 1) < 40:
+                print("-", end = "")
 
 def delete_downloaded_files() -> None:
     test = os.listdir('.')

--- a/flash_an_application.py
+++ b/flash_an_application.py
@@ -191,8 +191,8 @@ def print_out_dsk(serialno, board):
         print("DSK value: ", end = "")
         for x in range(40):
             print(sdk[x], end = "")
-            if (x + 1) % 5 == 0 and x > 0:
-                print(" - ", end = "")
+            if (x + 1) % 5 == 0 and x > 0 and (x + 1) < 40:
+                print("-", end = "")
 
 def delete_downloaded_files() -> None:
     test = os.listdir('.')


### PR DESCRIPTION
With this change the DSK can be copied directly into the PC Controller for Smart Start (previously it wouldn't accept the key because of the spaces). This also removes the extra trailing dash.